### PR TITLE
Update k8s.tf

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -53,12 +53,12 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     client_secret = var.client_secret
   }
 
-  addon_profile {
-    oms_agent {
-      enabled                    = true
-      log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-    }
-  }
+#  addon_profile {
+#    oms_agent {
+#      enabled                    = true
+#      log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+#    }
+#  }
 
   network_profile {
     load_balancer_sku = "Standard"


### PR DESCRIPTION
Resolves error. The 2.x version of the provider which is no longer actively maintained. Repo works in the v3.x version of the provider with other submitted changes.